### PR TITLE
Fix File Dialog Cancellation Error Messages in GUI

### DIFF
--- a/stdatalog_gui/HSD_GUI/Widgets/HSDLogControlWidget.py
+++ b/stdatalog_gui/HSD_GUI/Widgets/HSDLogControlWidget.py
@@ -302,7 +302,8 @@ class HSDLogControlWidget(ComponentWidget):
     @Slot()
     def clicked_load_config_button(self):
         fname = QFileDialog.getOpenFileName(None, "Load a Device Configuration file", "device_config", "JSON (*.json)")
-        self.controller.load_config(fname[0])
+        if fname[0]:  # Check if a file was actually selected (not cancelled)
+            self.controller.load_config(fname[0])
 
     @Slot()
     def checkBox_offline_checked(self, state):

--- a/stdatalog_gui/HSD_GUI/Widgets/HSDPlotLinesWidget.py
+++ b/stdatalog_gui/HSD_GUI/Widgets/HSDPlotLinesWidget.py
@@ -134,15 +134,16 @@ class HSDPlotLinesWidget(PlotLinesWavWidget):
     def clicked_load_out_fmt_button(self):
         json_filter = "JSON Output format description Files (*.json *.JSON)"
         filepath = QFileDialog.getOpenFileName(filter=json_filter)
-        self.__load_ispu_out_fmt(filepath[0])
-        if self.ispu_output_format is not None:
-            for id in range(len(self.legend.items)):
-                if id != 0:
-                    self.legend.removeItem(self.graph_curves[id])#
-                    self.legend.layout.removeAt(id)
-            self.legend.addItem(pg.PlotDataItem(pen=pg.mkPen(0,0,0,0)),"")
-            for i, of in enumerate(self.ispu_output_format):
-                self.legend.addItem(self.graph_curves[i], of.get("name",""))
+        if filepath[0]:  # Check if a file was actually selected (not cancelled)
+            self.__load_ispu_out_fmt(filepath[0])
+            if self.ispu_output_format is not None:
+                for id in range(len(self.legend.items)):
+                    if id != 0:
+                        self.legend.removeItem(self.graph_curves[id])#
+                        self.legend.layout.removeAt(id)
+                self.legend.addItem(pg.PlotDataItem(pen=pg.mkPen(0,0,0,0)),"")
+                for i, of in enumerate(self.ispu_output_format):
+                    self.legend.addItem(self.graph_curves[i], of.get("name",""))
     
     @Slot()
     def clicked_out_fmt_plot_settings_button(self):
@@ -408,5 +409,3 @@ class HSDPlotLinesWidget(PlotLinesWavWidget):
                     data_idx += ax_len
         else:
             super().add_data(data)
-
-    

--- a/stdatalog_gui/Widgets/CommandWidget.py
+++ b/stdatalog_gui/Widgets/CommandWidget.py
@@ -299,28 +299,31 @@ class CommandWidget(QWidget):
         if "_mlc" in self.comp_name:
             ucf_filter = "UCF Configuration files (*.ucf *.UCF)"
             filepath = QFileDialog.getOpenFileName(filter=ucf_filter)
-            self.loaded_file_path[file_id] = filepath[0]
-            self.loaded_file_value[file_id].setText(self.loaded_file_path[file_id])
-            if MLC_CmdValues.mlc_ucf in self.loaded_file_path and self.loaded_file_path[MLC_CmdValues.mlc_ucf] != "":
-                self.command_send_button.setEnabled(True)
-                self.command_send_button.setStyleSheet(STDTDL_PushButton.green)
-            else:
-                self.command_send_button.setEnabled(False)
-                self.command_send_button.setStyleSheet(STDTDL_PushButton.invalid)
+            if filepath[0]:  # Check if a file was actually selected (not cancelled)
+                self.loaded_file_path[file_id] = filepath[0]
+                self.loaded_file_value[file_id].setText(self.loaded_file_path[file_id])
+                if MLC_CmdValues.mlc_ucf in self.loaded_file_path and self.loaded_file_path[MLC_CmdValues.mlc_ucf] != "":
+                    self.command_send_button.setEnabled(True)
+                    self.command_send_button.setStyleSheet(STDTDL_PushButton.green)
+                else:
+                    self.command_send_button.setEnabled(False)
+                    self.command_send_button.setStyleSheet(STDTDL_PushButton.invalid)
         elif "_ispu" in self.comp_name:
             ext_filter = filter
             filepath = QFileDialog.getOpenFileName(filter=ext_filter)
-            self.loaded_file_path[file_id] = filepath[0]
-            self.loaded_file_value[file_id].setText(self.loaded_file_path[file_id])
-            if ISPU_CmdValues.ispu_ucf in self.loaded_file_path and self.loaded_file_path[ISPU_CmdValues.ispu_ucf] != "" and \
-               ISPU_CmdValues.ispu_json in self.loaded_file_path and self.loaded_file_path[ISPU_CmdValues.ispu_json] != "":
-                self.command_send_button.setEnabled(True)
-                self.command_send_button.setStyleSheet(STDTDL_PushButton.green)
-            else:
-                self.command_send_button.setEnabled(False)
-                self.command_send_button.setStyleSheet(STDTDL_PushButton.invalid)
+            if filepath[0]:  # Check if a file was actually selected (not cancelled)
+                self.loaded_file_path[file_id] = filepath[0]
+                self.loaded_file_value[file_id].setText(self.loaded_file_path[file_id])
+                if ISPU_CmdValues.ispu_ucf in self.loaded_file_path and self.loaded_file_path[ISPU_CmdValues.ispu_ucf] != "" and \
+                   ISPU_CmdValues.ispu_json in self.loaded_file_path and self.loaded_file_path[ISPU_CmdValues.ispu_json] != "":
+                    self.command_send_button.setEnabled(True)
+                    self.command_send_button.setStyleSheet(STDTDL_PushButton.green)
+                else:
+                    self.command_send_button.setEnabled(False)
+                    self.command_send_button.setStyleSheet(STDTDL_PushButton.invalid)
         else:
             filepath = QFileDialog.getOpenFileName()
-            self.loaded_file_path[file_id] = filepath[0]
-            self.loaded_file_value[file_id].setText(self.loaded_file_path[file_id])
-            self.controller.upload_file(self.loaded_file_path[file_id])
+            if filepath[0]:  # Check if a file was actually selected (not cancelled)
+                self.loaded_file_path[file_id] = filepath[0]
+                self.loaded_file_value[file_id].setText(self.loaded_file_path[file_id])
+                self.controller.upload_file(self.loaded_file_path[file_id])

--- a/stdatalog_gui/Widgets/ComponentWidget.py
+++ b/stdatalog_gui/Widgets/ComponentWidget.py
@@ -308,9 +308,10 @@ class ComponentWidget(QWidget):
     def clicked_browse_dt_button(self):
         json_filter = "JSON Device Template files (*.json *.JSON)"
         filepath = QFileDialog.getOpenFileName(filter=json_filter)
-        self.input_file_path = filepath[0]
-        self.dt_value.setText(self.input_file_path)
-        self.controller.load_local_device_template(self.input_file_path)
+        if filepath[0]:  # Check if a file was actually selected (not cancelled)
+            self.input_file_path = filepath[0]
+            self.dt_value.setText(self.input_file_path)
+            self.controller.load_local_device_template(self.input_file_path)
 
     @Slot()
     def clicked_show_button(self):

--- a/stdatalog_gui/Widgets/DeviceTemplateLoadingWidget.py
+++ b/stdatalog_gui/Widgets/DeviceTemplateLoadingWidget.py
@@ -47,9 +47,10 @@ class DeviceTemplateLoadingWidget(QWidget):
     def clicked_browse_dt_button(self):
         json_filter = "JSON Device Template files (*.json *.JSON)"
         filepath = QFileDialog.getOpenFileName(filter=json_filter)
-        self.input_file_path = filepath[0]
-        self.dt_value.setText(self.input_file_path)
-        # self.controller.load_local_device_template(self.input_file_path)
-        self.controller.add_custom_device_template(self.input_file_path)
+        if filepath[0]:  # Check if a file was actually selected (not cancelled)
+            self.input_file_path = filepath[0]
+            self.dt_value.setText(self.input_file_path)
+            # self.controller.load_local_device_template(self.input_file_path)
+            self.controller.add_custom_device_template(self.input_file_path)
 
-        self.controller.refresh()
+            self.controller.refresh()


### PR DESCRIPTION
**Fixes #1**

## Summary
This pull request fixes multiple instances of unhandled file dialog cancellation throughout the STDatalog GUI application. When users clicked "Cancel" or closed file selection dialogs, the application would generate `FileNotFoundError` messages in the console due to empty string file paths being passed to file processing functions. While the GUI continues to function normally, these error messages indicate improper error handling.

## Related Issue
- **Issue**: #1 - GUI displays error messages when canceling file selection dialogs
- **Link**: https://github.com/STMicroelectronics/stdatalog_gui/issues/1
- **Type**: Bug Fix  
- **Priority**: Low-Medium (Code Quality & User Experience Improvement)

## STMicroelectronics Contribution Compliance
- [x] Using latest commit version
- [x] Related to software provided in this repository (stdatalog_gui)
- [x] Checked for existing reports in Issues (open and closed)
- [x] CLA signed and verified at https://cla.st.com
- [x] One PR for one feature (file dialog validation fix)

## Problem Description
The STDatalog GUI contains several file browsing dialogs that allow users to select configuration files, device templates, and other files. However, when users cancelled these dialogs (by clicking "Cancel" or closing the dialog), the application would attempt to process an empty string as a file path, leading to crashes.

**This issue was discovered during active testing when a user cancelled the "Load Device Configuration" dialog and experienced an immediate application crash.**

### Error Details
- **Error Type**: `FileNotFoundError: [Errno 2] No such file or directory: ''`
- **Root Cause**: `QFileDialog.getOpenFileName()` returns a tuple where the first element is an empty string when cancelled
- **Impact**: Application crashes when users cancel file selection dialogs
- **User Experience**: Poor - users cannot safely cancel file dialogs without crashing the application
- **Critical Path**: The main crash occurred in `stdatalog_gui/HSD_GUI/Widgets/HSDLogControlWidget.py`

### Actual Error Traceback (Before Fix)
```
Traceback (most recent call last):
  File "stdatalog_gui/HSD_GUI/Widgets/HSDLogControlWidget.py", line 305, in clicked_load_config_button
    self.controller.load_config(fname[0])
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "stdatalog_gui/HSD_GUI/HSD_Controller.py", line 1232, in load_config
    self.hsd_link.update_device(self.device_id, fpath)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  [Error continues through stdatalog_core components...]
FileNotFoundError: [Errno 2] No such file or directory: ''
```

## Screenshots/Evidence
<img width="800" height="533" alt="Screenshot 2025-07-17 145240" src="https://github.com/user-attachments/assets/ee9793f4-494c-498c-b4af-832cb5461ce6" />


<img width="1561" height="1032" alt="Screenshot 2025-07-17 145253" src="https://github.com/user-attachments/assets/14b488b7-6ca5-4ef7-b22e-b472f26bdb80" />


## Technical Details

### Files Modified
The following 5 files within the `stdatalog_gui` repository have been modified to fix file dialog cancellation issues:

1. **`stdatalog_gui/HSD_GUI/Widgets/HSDLogControlWidget.py`**
   - **Method**: `clicked_load_config_button()`
   - **Line**: ~305
   - **Issue**: Device configuration file dialog cancellation
   - **Fix**: Added `if fname[0]:` validation before processing

2. **`stdatalog_gui/Widgets/ComponentWidget.py`**
   - **Method**: `clicked_browse_dt_button()`
   - **Line**: ~310
   - **Issue**: Device template file dialog cancellation
   - **Fix**: Added `if filepath[0]:` validation before processing

3. **`stdatalog_gui/Widgets/DeviceTemplateLoadingWidget.py`**
   - **Method**: `clicked_browse_dt_button()`
   - **Line**: ~49
   - **Issue**: Device template loading dialog cancellation
   - **Fix**: Added `if filepath[0]:` validation before processing

4. **`stdatalog_gui/Widgets/CommandWidget.py`**
   - **Method**: `clicked_browse_file_button()`
   - **Lines**: ~301, 312, 323
   - **Issue**: Multiple file type dialogs (UCF, ISPU, general files) cancellation
   - **Fix**: Added `if filepath[0]:` validation for all three dialog types

5. **`stdatalog_gui/HSD_GUI/Widgets/HSDPlotLinesWidget.py`**
   - **Method**: `clicked_load_out_fmt_button()`
   - **Line**: ~136
   - **Issue**: Output format file dialog cancellation
   - **Fix**: Added `if filepath[0]:` validation before processing

### Code Changes Pattern
All fixes follow the same pattern - adding a simple validation check:

```python
# Before (problematic code):
filepath = QFileDialog.getOpenFileName(filter=some_filter)
self.controller.some_method(filepath[0])  # Crashes if cancelled

# After (fixed code):
filepath = QFileDialog.getOpenFileName(filter=some_filter)
if filepath[0]:  # Check if a file was actually selected (not cancelled)
    self.controller.some_method(filepath[0])  # Only process if file selected
```

### Error Trace Analysis
The error typically propagated through this call chain:
1. User clicks file browser button
2. `QFileDialog.getOpenFileName()` called
3. User cancels dialog → returns `('', '')`
4. `filepath[0]` becomes empty string `''`
5. Empty string passed to file processing functions
6. File processing attempts to open `''` as file path
7. `FileNotFoundError` thrown → application crash

## Testing

### Test Cases
✅ **All test cases have been verified and confirmed working:**

1. **Load Device Configuration** (`HSDLogControlWidget`)
   - ✅ Click "Load Config" button
   - ✅ Cancel file dialog
   - ✅ Verify no crash occurs
   - ✅ Verify application remains functional
   - ✅ **CONFIRMED**: Fixed and tested

2. **Browse Device Template** (`ComponentWidget` & `DeviceTemplateLoadingWidget`)
   - ✅ Click "Browse" button for device template
   - ✅ Cancel file dialog
   - ✅ Verify no crash occurs
   - ✅ Verify application remains functional

3. **Upload Files** (`CommandWidget`)
   - ✅ Click file upload for MLC files (.ucf)
   - ✅ Cancel file dialog
   - ✅ Verify no crash occurs
   - ✅ Click file upload for ISPU files
   - ✅ Cancel file dialog  
   - ✅ Verify no crash occurs
   - ✅ Click general file upload
   - ✅ Cancel file dialog
   - ✅ Verify no crash occurs

4. **Load Output Format** (`HSDPlotLinesWidget`)
   - ✅ Click "Load Output Format" button
   - ✅ Cancel file dialog
   - ✅ Verify no crash occurs
   - ✅ Verify plotting functionality remains intact

### Real-World Testing Result
**BEFORE FIX**: Application crashed with `FileNotFoundError: [Errno 2] No such file or directory: ''` when canceling the "Load Device Configuration" dialog.

**AFTER FIX**: ✅ **CONFIRMED WORKING** - User can safely cancel file dialogs without any crashes or errors.

### Testing Environment
- **OS**: Windows 11
- **Python**: 3.13.5
- **PySide6**: 6.9.0
- **Repository**: stdatalog_gui (STMicroelectronics)
- **Framework**: PySide6-based GUI application

## Backward Compatibility
✅ **No breaking changes** - This fix only adds validation logic and does not modify any existing APIs, method signatures, or behavior for successful file selections.

## Performance Impact
✅ **Minimal performance impact** - Only adds a simple string validation check (`if filepath[0]:`) which has negligible performance overhead.

## Code Quality
- **Follows existing code patterns**: Uses same coding style and patterns as existing codebase
- **Consistent implementation**: Same fix pattern applied across all affected files
- **Minimal code changes**: Only adds necessary validation without refactoring existing logic
- **Clear comments**: Added explanatory comments for the validation checks

## Risk Assessment
- **Risk Level**: **Low**
- **Impact**: Positive - prevents crashes and improves user experience
- **Side Effects**: None identified
- **Rollback**: Easy - simple revert of validation checks

## Benefits
1. **Improved User Experience**: Users can safely cancel file dialogs without crashing the application
2. **Increased Stability**: Eliminates a common crash scenario in the GUI
3. **Better Error Handling**: Graceful handling of user cancellation actions
4. **Maintainability**: Consistent pattern for handling file dialogs across the codebase

## Additional Notes
- This fix addresses a user experience issue that could discourage users from exploring the application's file loading features
- The fix is defensive programming - handling a valid user action (cancelling a dialog) that should never cause a crash
- All modified files maintain their original functionality while adding robustness
- The fix was confirmed working through real-world testing where the previously crashing dialog cancellation now works seamlessly
- **Scope**: This PR only addresses GUI-level validation in the `stdatalog_gui` repository. The underlying file processing logic remains in `stdatalog_core`

## Implementation Notes
### GUI-Level Validation Approach
This fix implements validation at the GUI layer within the `stdatalog_gui` repository:
- **Input Validation**: Added file selection validation before passing paths to underlying controllers
- **Error Prevention**: Prevents empty file paths from reaching file processing functions in `stdatalog_core`
- **User Experience**: Provides graceful handling of dialog cancellation without changing core functionality

### Repository Scope
This PR is scoped specifically to the `stdatalog_gui` repository and:
- Does not modify any `stdatalog_core` functionality
- Maintains all existing API contracts with core components
- Implements defensive programming at the GUI boundary layer

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex validation logic
- [x] All file dialog cancellation scenarios tested
- [x] No breaking changes introduced
- [x] Documentation updated (this PR document)

---